### PR TITLE
hide imagenet classes into form; add arxiv link

### DIFF
--- a/misc/poolformer_demo.ipynb
+++ b/misc/poolformer_demo.ipynb
@@ -9,7 +9,7 @@
         "# MetaFormer is Actually What You Need for Vision\n",
         "\n",
         "This is a demo example to run PoolFormer for image classification, from \n",
-        "[MetaFormer is Actually What You Need for Vision](https://arxiv.org/abs/XXXX.XXXXX). \n",
+        "[MetaFormer is Actually What You Need for Vision](https://arxiv.org/abs/2111.11418). \n",
         "\n",
         "More detail can be found in [this repo](https://github.com/sail-sg/poolformer).\n"
       ]
@@ -148,10 +148,12 @@
       "cell_type": "code",
       "execution_count": 7,
       "metadata": {
+        "cellView": "form",
         "id": "Rnh5qi6rgk3a"
       },
       "outputs": [],
       "source": [
+        "#@title ImageNet classes\n",
         "imagenet_classes = {0: 'tench, Tinca tinca',\n",
         " 1: 'goldfish, Carassius auratus',\n",
         " 2: 'great white shark, white shark, man-eater, man-eating shark, Carcharodon carcharias',\n",
@@ -1199,15 +1201,6 @@
         "print(f'Prediction: {imagenet_classes[int(pred.argmax())]}.')\n",
         "image"
       ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "lRnoN3TjoBOB"
-      },
-      "outputs": [],
-      "source": []
     }
   ],
   "metadata": {


### PR DESCRIPTION
Hi.
- hide huge cell with ImageNet classes into form cell (difference can be viewed in colab):
![image](https://user-images.githubusercontent.com/36787333/144762370-796e985e-1901-48e5-89cf-4d190b8bee46.png)
- added link to arxiv paper.
