### PR TITLE
Emptying cache for GPU memory leakage after every epoch

### DIFF
--- a/train.py
+++ b/train.py
@@ -619,6 +619,8 @@ def main():
             if args.distributed and hasattr(loader_train.sampler, 'set_epoch'):
                 loader_train.sampler.set_epoch(epoch)
 
+            torch.cuda.empty_cache()
+
             train_metrics = train_one_epoch(
                 epoch, model, loader_train, optimizer, train_loss_fn, args,
                 lr_scheduler=lr_scheduler, saver=saver, output_dir=output_dir,


### PR DESCRIPTION
Hi, I observed GPU memory leakage after every epoch, I couldn't find the root cause but emptying the cache fixed it, might be helpful.